### PR TITLE
Add Different OutputMethods for storing Env Variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@
 # Maven
 log/
 target/
+/docker/vault/.cache/*
+/docker/vault/appRole.properties

--- a/docker/vault/enable-github-auth.sh
+++ b/docker/vault/enable-github-auth.sh
@@ -1,12 +1,9 @@
 vault login 6edb70bd-3398-1f42-d67e-b9db377223cd
-
 vault auth enable github
 vault write auth/github/config organization=vault-plugin-test organization-id=0
 vault write auth/github/map/teams/test-team value=dev-policy
-
 vault auth enable approle
 vault write auth/approle/role/test-role token_policies=dev-policy
 vault read auth/approle/role/test-role/role-id | tail -n 1 | sed 's/ /\n/g' | tail -n 1 | sed 's/\(.*\)/roleId=\1/' >> /home/vault/appRole.properties
 vault write -f auth/approle/role/test-role/secret-id | sed -n '3{p;q}' | sed 's/ /\n/g' | tail -n 1 | sed 's/\(.*\)/secretId=\1/' >> /home/vault/appRole.properties
-
 vault policy write dev-policy /home/vault/dev-policy.hcl

--- a/src/main/java/com/homeofthewizard/maven/plugins/vault/PullMojo.java
+++ b/src/main/java/com/homeofthewizard/maven/plugins/vault/PullMojo.java
@@ -47,7 +47,7 @@ public class PullMojo extends VaultMojo {
       return;
     }
     try {
-      vaultClient.pull(this.servers, this.project.getProperties());
+      vaultClient.pull(this.servers, this.project.getProperties(), this.outputMethod);
     } catch (VaultException exception) {
       throw new MojoExecutionException("Exception thrown pulling secrets.", exception);
     }

--- a/src/main/java/com/homeofthewizard/maven/plugins/vault/VaultMojo.java
+++ b/src/main/java/com/homeofthewizard/maven/plugins/vault/VaultMojo.java
@@ -21,6 +21,7 @@ import com.homeofthewizard.maven.plugins.vault.client.VaultBackendProvider;
 import com.homeofthewizard.maven.plugins.vault.client.VaultClient;
 import com.homeofthewizard.maven.plugins.vault.config.AuthenticationMethodFactory;
 import com.homeofthewizard.maven.plugins.vault.config.AuthenticationMethodProvider;
+import com.homeofthewizard.maven.plugins.vault.config.OutputMethod;
 import com.homeofthewizard.maven.plugins.vault.config.Server;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -28,7 +29,6 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 
 import java.util.List;
-
 
 /**
  * Provides an abstract class for mojos that work with Vault.
@@ -40,6 +40,9 @@ abstract class VaultMojo extends AbstractMojo {
 
   @Parameter(required = true)
   protected List<Server> servers;
+
+  @Parameter(defaultValue = "MavenProperties")
+  protected OutputMethod outputMethod;
 
   @Parameter(property = "skipExecution", defaultValue = "false")
   protected boolean skipExecution;

--- a/src/main/java/com/homeofthewizard/maven/plugins/vault/client/VaultClient.java
+++ b/src/main/java/com/homeofthewizard/maven/plugins/vault/client/VaultClient.java
@@ -2,6 +2,7 @@ package com.homeofthewizard.maven.plugins.vault.client;
 
 import com.bettercloud.vault.VaultException;
 import com.homeofthewizard.maven.plugins.vault.config.AuthenticationMethodProvider;
+import com.homeofthewizard.maven.plugins.vault.config.OutputMethod;
 import com.homeofthewizard.maven.plugins.vault.config.Server;
 
 import java.util.List;
@@ -21,7 +22,7 @@ public interface VaultClient {
     return new Vaults(new VaultBackendProvider());
   }
 
-  void pull(List<Server> servers, Properties properties) throws VaultException;
+  void pull(List<Server> servers, Properties properties, OutputMethod outputMethod) throws VaultException;
 
   void push(List<Server> servers, Properties properties) throws VaultException;
 

--- a/src/main/java/com/homeofthewizard/maven/plugins/vault/client/Vaults.java
+++ b/src/main/java/com/homeofthewizard/maven/plugins/vault/client/Vaults.java
@@ -8,6 +8,7 @@ import com.bettercloud.vault.Vault;
 import com.bettercloud.vault.VaultException;
 import com.homeofthewizard.maven.plugins.vault.config.AuthenticationMethodProvider;
 import com.homeofthewizard.maven.plugins.vault.config.Mapping;
+import com.homeofthewizard.maven.plugins.vault.config.OutputMethod;
 import com.homeofthewizard.maven.plugins.vault.config.Path;
 import com.homeofthewizard.maven.plugins.vault.config.Server;
 
@@ -36,12 +37,13 @@ final class Vaults implements VaultClient {
   /**
    * Pulls secrets from one or more Vault servers and paths and updates a {@link Properties} instance with the values.
    *
-   * @param servers the servers
-   * @param properties the properties
+   * @param servers      the servers
+   * @param properties   the properties
+   * @param outputMethod the output method
    * @throws VaultException if an exception is throw pulling the secrets
    */
   @Override
-  public void pull(List<Server> servers, Properties properties) throws VaultException {
+  public void pull(List<Server> servers, Properties properties, OutputMethod outputMethod) throws VaultException {
     for (Server server : servers) {
       if (server.isSkipExecution()) {
         continue;
@@ -56,6 +58,7 @@ final class Vaults implements VaultClient {
             throw new NoSuchElementException(message);
           }
           properties.setProperty(mapping.getProperty(), secrets.get(mapping.getKey()));
+          outputMethod.flush(properties, secrets, mapping);
         }
       }
     }

--- a/src/main/java/com/homeofthewizard/maven/plugins/vault/config/OutputMethod.java
+++ b/src/main/java/com/homeofthewizard/maven/plugins/vault/config/OutputMethod.java
@@ -1,0 +1,64 @@
+package com.homeofthewizard.maven.plugins.vault.config;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Map;
+import java.util.Properties;
+
+public enum OutputMethod {
+  MavenProperties{
+    @Override
+    public void flush(Properties properties, Map<String, String> secrets, Mapping mapping) {
+      setMavenProperties(properties, secrets, mapping);
+    }
+  },
+  SystemProperties{
+    @Override
+    public void flush(Properties properties, Map<String, String> secrets, Mapping mapping) {
+      setSystemProperties(secrets, mapping);
+    }
+  },
+  EnvFile{
+    @Override
+    public void flush(Properties properties, Map<String, String> secrets, Mapping mapping) {
+      setEnvFile(secrets, mapping);
+    }
+  };
+
+  public abstract void flush(Properties properties, Map<String, String> secrets, Mapping mapping);
+
+  /**
+   * Creates an .envFile and put the secrets in it, respecting the key/property mapping definition given.
+   * @param secrets secrets fetched from Vault.
+   * @param mapping mapping defined in maven project.
+   */
+  private static void setEnvFile(Map<String, String> secrets, Mapping mapping) {
+    Properties prop = new Properties();
+    try (OutputStream outputStream = new FileOutputStream(".env")) {
+      prop.setProperty(mapping.getProperty(), secrets.get(mapping.getKey()));
+      prop.store(outputStream, null);
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+  }
+
+  /**
+   * Sets the secrets in System.getProperties(), respecting the key/property mapping definition given.
+   * @param secrets secrets fetched from Vault.
+   * @param mapping mapping defined in maven project.
+   */
+  private static void setSystemProperties(Map<String, String> secrets, Mapping mapping) {
+    System.setProperty(mapping.getProperty(), secrets.get(mapping.getKey()));
+  }
+
+  /**
+   * Sets the secrets in mavenProject.properties, respecting the key/property mapping definition given.
+   * @param properties maven project properties
+   * @param secrets secrets fetched from Vault.
+   * @param mapping mapping defined in maven project.
+   */
+  private static void setMavenProperties(Properties properties, Map<String, String> secrets, Mapping mapping) {
+    properties.setProperty(mapping.getProperty(), secrets.get(mapping.getKey()));
+  }
+}

--- a/src/test/java/com/homeofthewizard/maven/plugins/vault/IntTestAuth.java
+++ b/src/test/java/com/homeofthewizard/maven/plugins/vault/IntTestAuth.java
@@ -130,7 +130,7 @@ public class IntTestAuth {
             var client = VaultClient.create();
             try {
                 mojo.execute();
-                client.pull(fixture.servers, properties);
+                client.pull(fixture.servers, properties, OutputMethod.MavenProperties);
                 assertTrue(Maps.difference(fixture.properties, mojo.project.getProperties()).areEqual());
             } catch (MojoExecutionException exception) {
                 fail(String.format("Unexpected exception while executing: %s", exception.getMessage()));
@@ -160,7 +160,7 @@ public class IntTestAuth {
             var client = VaultClient.create();
             try {
                 mojo.execute();
-                client.pull(fixture.servers, properties);
+                client.pull(fixture.servers, properties, OutputMethod.MavenProperties);
                 assertTrue(Maps.difference(fixture.properties, mojo.project.getProperties()).areEqual());
             } catch (MojoExecutionException exception) {
                 fail(String.format("Unexpected exception while executing: %s", exception.getMessage()));
@@ -178,6 +178,7 @@ public class IntTestAuth {
             mojo.project = new MavenProject();
             mojo.servers = fixture.servers;
             mojo.skipExecution = false;
+            mojo.outputMethod = OutputMethod.MavenProperties;
             var client = VaultClient.create();
             fixture.properties.stringPropertyNames().forEach(key -> {
                 mojo.project.getProperties().setProperty(key, fixture.properties.getProperty(key));
@@ -202,6 +203,7 @@ public class IntTestAuth {
             mojo.project = new MavenProject();
             mojo.servers = fixture.servers;
             mojo.skipExecution = false;
+            mojo.outputMethod = OutputMethod.MavenProperties;
             var client = VaultClient.create();
             fixture.properties.stringPropertyNames().forEach(key -> {
                 mojo.project.getProperties().setProperty(key, fixture.properties.getProperty(key));

--- a/src/test/java/com/homeofthewizard/maven/plugins/vault/IntTestPullMojo.java
+++ b/src/test/java/com/homeofthewizard/maven/plugins/vault/IntTestPullMojo.java
@@ -20,10 +20,7 @@ import com.bettercloud.vault.VaultException;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 import com.homeofthewizard.maven.plugins.vault.client.VaultClient;
-import com.homeofthewizard.maven.plugins.vault.config.AuthenticationMethodFactory;
-import com.homeofthewizard.maven.plugins.vault.config.GithubToken;
-import com.homeofthewizard.maven.plugins.vault.config.Path;
-import com.homeofthewizard.maven.plugins.vault.config.Server;
+import com.homeofthewizard.maven.plugins.vault.config.*;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.project.MavenProject;
 import org.junit.jupiter.api.Test;
@@ -89,6 +86,7 @@ public class IntTestPullMojo {
       mojo.project = new MavenProject();
       mojo.servers = fixture.servers;
       mojo.skipExecution = false;
+      mojo.outputMethod = OutputMethod.MavenProperties;
       var client = VaultClient.create();
       try {
         client.push(fixture.servers, fixture.properties);
@@ -109,6 +107,7 @@ public class IntTestPullMojo {
       mojo.project = new MavenProject();
       mojo.servers = fixture.servers;
       mojo.skipExecution = false;
+      mojo.outputMethod = OutputMethod.MavenProperties;
       var client = VaultClient.create();
       try {
         client.push(fixture.servers, fixture.properties);
@@ -129,6 +128,7 @@ public class IntTestPullMojo {
       mojo.project = new MavenProject();
       mojo.servers = fixture.servers;
       mojo.skipExecution = true;
+      mojo.outputMethod = OutputMethod.MavenProperties;
       var client = VaultClient.create();
       try {
         client.push(fixture.servers, fixture.properties);

--- a/src/test/java/com/homeofthewizard/maven/plugins/vault/IntTestPushMojo.java
+++ b/src/test/java/com/homeofthewizard/maven/plugins/vault/IntTestPushMojo.java
@@ -20,10 +20,7 @@ import com.bettercloud.vault.VaultException;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 import com.homeofthewizard.maven.plugins.vault.client.VaultClient;
-import com.homeofthewizard.maven.plugins.vault.config.AuthenticationMethodFactory;
-import com.homeofthewizard.maven.plugins.vault.config.GithubToken;
-import com.homeofthewizard.maven.plugins.vault.config.Path;
-import com.homeofthewizard.maven.plugins.vault.config.Server;
+import com.homeofthewizard.maven.plugins.vault.config.*;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.project.MavenProject;
 import org.junit.jupiter.api.Test;
@@ -96,7 +93,7 @@ public class IntTestPushMojo {
       var client = VaultClient.create();
       try {
         mojo.execute();
-        client.pull(fixture.servers, properties);
+        client.pull(fixture.servers, properties, OutputMethod.MavenProperties);
         assertTrue(Maps.difference(fixture.properties, mojo.project.getProperties()).areEqual());
       } catch (MojoExecutionException exception) {
         fail(String.format("Unexpected exception while executing: %s", exception.getMessage()));
@@ -113,6 +110,7 @@ public class IntTestPushMojo {
             mojo.project = new MavenProject();
             mojo.servers = fixture.servers;
             mojo.skipExecution = false;
+            mojo.outputMethod = OutputMethod.MavenProperties;
             var client = VaultClient.create();
             try {
                 client.push(fixture.servers, fixture.properties);

--- a/src/test/java/com/homeofthewizard/maven/plugins/vault/IntTestVaults.java
+++ b/src/test/java/com/homeofthewizard/maven/plugins/vault/IntTestVaults.java
@@ -80,7 +80,7 @@ public class IntTestVaults {
   }
 
   /**
-   * Tests the {@link VaultClient#pull(List, Properties)} and {@link VaultClient#push(List, Properties)} methods.
+   * Tests the {@link VaultClient#pull(List, Properties, OutputMethod)} and {@link VaultClient#push(List, Properties)} methods.
    *
    * @throws URISyntaxException if an exception is raised parsing the certificate
    */
@@ -92,7 +92,7 @@ public class IntTestVaults {
         client.push(fixture.servers, fixture.properties);
         Properties properties = new Properties();
         try {
-          client.pull(fixture.servers, properties);
+          client.pull(fixture.servers, properties, OutputMethod.MavenProperties);
           assertTrue(Maps.difference(fixture.properties, properties).areEqual());
         } catch (VaultException exception) {
           fail(String.format("Unexpected exception while pulling to Vault: %s", exception.getMessage()));

--- a/src/test/java/com/homeofthewizard/maven/plugins/vault/TestPullMojo.java
+++ b/src/test/java/com/homeofthewizard/maven/plugins/vault/TestPullMojo.java
@@ -3,11 +3,7 @@ package com.homeofthewizard.maven.plugins.vault;
 import com.bettercloud.vault.VaultException;
 import com.google.common.collect.ImmutableList;
 import com.homeofthewizard.maven.plugins.vault.client.VaultClient;
-import com.homeofthewizard.maven.plugins.vault.config.AuthenticationMethodFactory;
-import com.homeofthewizard.maven.plugins.vault.config.AuthenticationMethodProvider;
-import com.homeofthewizard.maven.plugins.vault.config.Path;
-import com.homeofthewizard.maven.plugins.vault.config.Server;
-import com.homeofthewizard.maven.plugins.vault.config.GithubToken;
+import com.homeofthewizard.maven.plugins.vault.config.*;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.project.MavenProject;
 import org.junit.jupiter.api.Assertions;
@@ -46,7 +42,7 @@ public class TestPullMojo {
         var authenticationMethodProvider = Mockito.mock(AuthenticationMethodProvider.class);
         var client = Mockito.mock(VaultClient.class);
         doNothing().when(client).authenticateIfNecessary(any(),any());
-        doNothing().when(client).pull(any(),any());
+        doNothing().when(client).pull(any(),any(),any());
 
         var mojo = new PullMojo(authenticationMethodProvider, client);
         mojo.project = new MavenProject();
@@ -55,7 +51,7 @@ public class TestPullMojo {
 
         mojo.execute();
 
-        verify(client, times(0)).pull(any(),any());
+        verify(client, times(0)).pull(any(),any(),any());
         verify(client, times(0)).authenticateIfNecessary(any(),any());
     }
 
@@ -65,7 +61,7 @@ public class TestPullMojo {
         var authenticationMethodProvider = Mockito.mock(AuthenticationMethodProvider.class);
         var client = Mockito.mock(VaultClient.class);
         doNothing().when(client).authenticateIfNecessary(any(),any());
-        doNothing().when(client).pull(any(),any());
+        doNothing().when(client).pull(any(),any(),any());
 
         var mojo = new PullMojo(authenticationMethodProvider, client);
         mojo.project = new MavenProject();
@@ -74,7 +70,7 @@ public class TestPullMojo {
 
         mojo.execute();
 
-        verify(client, times(1)).pull(any(),any());
+        verify(client, times(1)).pull(any(),any(),any());
         verify(client, times(1)).authenticateIfNecessary(any(),any());
     }
 
@@ -83,7 +79,7 @@ public class TestPullMojo {
         List<Path> paths = randomPaths(10, 10);
         var authenticationMethodProvider = Mockito.mock(AuthenticationMethodProvider.class);
         var client = Mockito.mock(VaultClient.class);
-        doNothing().when(client).pull(any(),any());
+        doNothing().when(client).pull(any(),any(),any());
 
         var mojo = new PullMojo(authenticationMethodProvider, client);
         mojo.project = new MavenProject();
@@ -92,7 +88,7 @@ public class TestPullMojo {
 
         mojo.executeVaultOperation();
 
-        verify(client, times(1)).pull(any(),any());
+        verify(client, times(1)).pull(any(),any(),any());
     }
 
     @Test
@@ -109,7 +105,7 @@ public class TestPullMojo {
 
         mojo.executeVaultOperation();
 
-        verify(client, times(0)).pull(any(),any());
+        verify(client, times(0)).pull(any(),any(),any());
     }
 
     @Test
@@ -118,7 +114,7 @@ public class TestPullMojo {
         var authenticationMethodProvider = Mockito.mock(AuthenticationMethodProvider.class);
         var client = Mockito.mock(VaultClient.class);
         doThrow(VaultException.class).when(client).authenticateIfNecessary(any(),any());
-        doNothing().when(client).pull(any(),any());
+        doNothing().when(client).pull(any(),any(),any());
 
         var mojo = new PullMojo(authenticationMethodProvider, client);
         mojo.project = new MavenProject();
@@ -127,7 +123,7 @@ public class TestPullMojo {
 
         Assertions.assertThrows(MojoExecutionException.class, ()-> mojo.execute());
         verify(client, times(1)).authenticateIfNecessary(any(),any());
-        verify(client, times(0)).pull(any(),any());
+        verify(client, times(0)).pull(any(),any(),any());
     }
 
     @Test
@@ -135,7 +131,7 @@ public class TestPullMojo {
         List<Path> paths = randomPaths(10, 10);
         var authenticationMethodProvider = Mockito.mock(AuthenticationMethodProvider.class);
         var client = Mockito.mock(VaultClient.class);
-        doThrow(VaultException.class).when(client).pull(any(),any());
+        doThrow(VaultException.class).when(client).pull(any(),any(),any());
 
         var mojo = new PullMojo(authenticationMethodProvider, client);
         mojo.project = new MavenProject();

--- a/src/test/java/com/homeofthewizard/maven/plugins/vault/client/TestVaults.java
+++ b/src/test/java/com/homeofthewizard/maven/plugins/vault/client/TestVaults.java
@@ -57,7 +57,7 @@ public class TestVaults {
         when(vaultBackendProviderMock.vault(any(),any(),any(),anyBoolean(),any(),any())).thenReturn(null);
         var vaultClient = VaultClient.createForBackend(vaultBackendProviderMock);
 
-        vaultClient.pull(List.of(server), null);
+        vaultClient.pull(List.of(server), null, OutputMethod.MavenProperties);
 
         verify(vaultBackendProviderMock, times(0)).vault(any(),any(),any(),anyBoolean(),any(),any());
     }
@@ -82,7 +82,7 @@ public class TestVaults {
         when(vaultBackendProviderMock.vault(any(),any(),any(),anyBoolean(),any(),any())).thenReturn(vaultMock);
         var vaultClient = VaultClient.createForBackend(vaultBackendProviderMock);
 
-        vaultClient.pull(List.of(server), null);
+        vaultClient.pull(List.of(server), null, OutputMethod.MavenProperties);
 
         verify(vaultBackendProviderMock, times(1)).vault(any(),any(),any(),anyBoolean(),any(),any());
     }
@@ -109,7 +109,7 @@ public class TestVaults {
         when(vaultBackendProviderMock.vault(any(),any(),any(),anyBoolean(),any(),any())).thenReturn(vaultMock);
         var vaultClient = VaultClient.createForBackend(vaultBackendProviderMock);
 
-        vaultClient.pull(List.of(server), new Properties());
+        vaultClient.pull(List.of(server), new Properties(), OutputMethod.MavenProperties);
 
         verify(vaultBackendProviderMock, times(1)).vault(any(),any(),any(),anyBoolean(),any(),any());
     }

--- a/src/test/java/com/homeofthewizard/maven/plugins/vault/config/TestOutputMethod.java
+++ b/src/test/java/com/homeofthewizard/maven/plugins/vault/config/TestOutputMethod.java
@@ -1,0 +1,55 @@
+package com.homeofthewizard.maven.plugins.vault.config;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Properties;
+
+public class TestOutputMethod {
+
+    @Test
+    public void shouldStoreMavenProperties(){
+        var mavenPropOutMethod = OutputMethod.MavenProperties;
+        var properties = new Properties();
+        var secrets = new HashMap<String, String>();
+        secrets.put("testSecretKey", "testSecretVal");
+        var mapping = new Mapping("testSecretKey", "testPropertyName");
+
+        mavenPropOutMethod.flush(properties, secrets, mapping);
+
+        Assertions.assertTrue(properties.containsKey("testPropertyName"));
+        Assertions.assertTrue(properties.getProperty("testPropertyName").equals("testSecretVal"));
+    }
+
+    @Test
+    public void shouldStoreSystemProperties(){
+        var sysPropOutMethod = OutputMethod.SystemProperties;
+        var properties = new Properties();
+        var secrets = new HashMap<String, String>();
+        secrets.put("testSecretKey", "testSecretVal");
+        var mapping = new Mapping("testSecretKey", "testPropertyName");
+
+        sysPropOutMethod.flush(properties, secrets, mapping);
+
+        Assertions.assertTrue(System.getProperties().containsKey("testPropertyName"));
+        Assertions.assertTrue(System.getProperty("testPropertyName").equals("testSecretVal"));
+    }
+
+    @Test
+    public void shouldStoreEnvFile(){
+        var envFileOutMethod = OutputMethod.EnvFile;
+        var properties = new Properties();
+        var secrets = new HashMap<String, String>();
+        secrets.put("testSecretKey", "testSecretVal");
+        var mapping = new Mapping("testSecretKey", "testPropertyName");
+
+        envFileOutMethod.flush(properties, secrets, mapping);
+
+        var envFile = Paths.get(".env").toFile();
+        Assertions.assertTrue(envFile.exists());
+        envFile.delete();
+    }
+}


### PR DESCRIPTION
Different methods allows to answer different use cases.

- Storging the secrets to Maven properties (Default)
- Storing the secrets to Maven's System properties
- Storing the secrets in a .env file